### PR TITLE
Supported *.{gjs,gts} files

### DIFF
--- a/.changeset/pretty-laws-roll.md
+++ b/.changeset/pretty-laws-roll.md
@@ -1,0 +1,5 @@
+---
+"ember-codemod-remove-inject-as-service": minor
+---
+
+Supported \*.{gjs,gts} files

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@codemod-utils/ast-javascript": "^2.0.6",
+    "@codemod-utils/ast-template-tag": "^0.1.0",
     "@codemod-utils/files": "^3.0.4",
     "yargs": "^18.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@codemod-utils/ast-javascript':
         specifier: ^2.0.6
         version: 2.0.6
+      '@codemod-utils/ast-template-tag':
+        specifier: ^0.1.0
+        version: 0.1.0
       '@codemod-utils/files':
         specifier: ^3.0.4
         version: 3.0.4
@@ -201,6 +204,10 @@ packages:
 
   '@codemod-utils/ast-javascript@2.0.6':
     resolution: {integrity: sha512-UcIdtWxgthxMu2V1sXq9qSFTnkWvUlJJIQGjS0tvtc3PnTiX1/qfvPhdsD8Nt4cWYjDBpNpsKSkCY/UIeAfPLw==}
+    engines: {node: 20.* || >= 22}
+
+  '@codemod-utils/ast-template-tag@0.1.0':
+    resolution: {integrity: sha512-iHsPCM6c6vwJ0aylfSs4Ir3q/Sah29yfOPKyk8Hry8WmjelE1rIr5NKqMIZMxuABuLWmV0OJl6lBYlqFRYFLzw==}
     engines: {node: 20.* || >= 22}
 
   '@codemod-utils/files@3.0.4':
@@ -2314,6 +2321,10 @@ snapshots:
     dependencies:
       '@babel/parser': 7.28.4
       recast: 0.23.11
+
+  '@codemod-utils/ast-template-tag@0.1.0':
+    dependencies:
+      content-tag: 4.0.0
 
   '@codemod-utils/files@3.0.4':
     dependencies:

--- a/src/steps/create-options.ts
+++ b/src/steps/create-options.ts
@@ -3,11 +3,11 @@ import type { CodemodOptions, Options } from '../types/index.js';
 function getSrc(projectType: CodemodOptions['projectType']): string[] {
   switch (projectType) {
     case 'app': {
-      return ['app/**/*.{js,ts}', 'tests/**/*.{js,ts}'];
+      return ['{app,tests}/**/*.{js,ts}'];
     }
 
     case 'v1-addon': {
-      return ['addon/**/*.{js,ts}', 'tests/**/*.{js,ts}'];
+      return ['{addon,tests}/**/*.{js,ts}'];
     }
 
     case 'v2-addon': {

--- a/src/steps/create-options.ts
+++ b/src/steps/create-options.ts
@@ -3,15 +3,15 @@ import type { CodemodOptions, Options } from '../types/index.js';
 function getSrc(projectType: CodemodOptions['projectType']): string[] {
   switch (projectType) {
     case 'app': {
-      return ['{app,tests}/**/*.{js,ts}'];
+      return ['{app,tests}/**/*.{gjs,gts,js,ts}'];
     }
 
     case 'v1-addon': {
-      return ['{addon,tests}/**/*.{js,ts}'];
+      return ['{addon,tests}/**/*.{gjs,gts,js,ts}'];
     }
 
     case 'v2-addon': {
-      return ['src/**/*.{js,ts}'];
+      return ['src/**/*.{gjs,gts,js,ts}'];
     }
   }
 }

--- a/src/steps/update-project.ts
+++ b/src/steps/update-project.ts
@@ -6,6 +6,10 @@ import { findFiles } from '@codemod-utils/files';
 import type { Options } from '../types/index.js';
 import { updateClass } from './update-project/update-class.js';
 
+function isTypeScript(filePath: string): boolean {
+  return filePath.endsWith('.gts') || filePath.endsWith('.ts');
+}
+
 export function updateProject(options: Options): void {
   const { projectRoot, src } = options;
 
@@ -15,11 +19,13 @@ export function updateProject(options: Options): void {
 
   filePaths.forEach((filePath) => {
     const oldPath = join(projectRoot, filePath);
-    const oldFile = readFileSync(oldPath, 'utf8');
+    let newFile = readFileSync(oldPath, 'utf8');
 
-    const isTypeScript = filePath.endsWith('.ts');
+    const data = {
+      isTypeScript: isTypeScript(filePath),
+    };
 
-    const newFile = updateClass(oldFile, isTypeScript);
+    newFile = updateClass(newFile, data);
 
     writeFileSync(oldPath, newFile, 'utf8');
   });

--- a/src/steps/update-project.ts
+++ b/src/steps/update-project.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { updateJavaScript } from '@codemod-utils/ast-template-tag';
 import { findFiles } from '@codemod-utils/files';
 
 import type { Options } from '../types/index.js';
@@ -25,7 +26,13 @@ export function updateProject(options: Options): void {
       isTypeScript: isTypeScript(filePath),
     };
 
-    newFile = updateClass(newFile, data);
+    if (filePath.endsWith('.js') || filePath.endsWith('.ts')) {
+      newFile = updateClass(newFile, data);
+    } else {
+      newFile = updateJavaScript(newFile, (code) => {
+        return updateClass(code, data);
+      });
+    }
 
     writeFileSync(oldPath, newFile, 'utf8');
   });

--- a/src/steps/update-project/update-class.ts
+++ b/src/steps/update-project/update-class.ts
@@ -143,7 +143,13 @@ function updateServiceDecorators(
   return AST.print(ast);
 }
 
-export function updateClass(file: string, isTypeScript: boolean): string {
+type Data = {
+  isTypeScript: boolean;
+};
+
+export function updateClass(file: string, data: Data): string {
+  const { isTypeScript } = data;
+
   // eslint-disable-next-line prefer-const
   let { localName, newFile } = updateImportStatement(file, {
     isTypeScript,

--- a/tests/fixtures/my-app/input/app/components/example-1.gts
+++ b/tests/fixtures/my-app/input/app/components/example-1.gts
@@ -1,0 +1,25 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+import type ApiService from '../services/api';
+import type CurrentUserService from '../services/current-user';
+import type Domain1BusinessLogicService from '../services/domain-1/business-logic';
+
+export default class Example1Component extends Component {
+  @service('domain-1/business-logic')
+  declare domain1BusinessLogic: Domain1BusinessLogicService;
+
+  @service declare currentUser: CurrentUserService;
+  @service declare api: ApiService;
+
+  @action async consent(): Promise<void> {
+    const id = this.currentUser.user!.id;
+
+    await this.api.post('consent', { id });
+  }
+
+  <template>
+    Template goes here
+  </template>
+}

--- a/tests/fixtures/my-app/input/app/components/example-2.gts
+++ b/tests/fixtures/my-app/input/app/components/example-2.gts
@@ -1,0 +1,23 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+import type ApiService from '../services/api';
+import type CurrentUserService from '../services/current-user';
+import type Domain1BusinessLogicService from '../services/domain-1/business-logic';
+
+export default class Example2Component extends Component {
+  <template>
+    Template goes here
+  </template>
+
+  @service('domain-1/business-logic') declare dbl: Domain1BusinessLogicService;
+  @service('current-user') declare user: CurrentUserService;
+  @service('api') declare xyz: ApiService;
+
+  @action async consent(): Promise<void> {
+    const id = this.user.user!.id;
+
+    await this.xyz.post('consent', { id });
+  }
+}

--- a/tests/fixtures/my-app/input/app/components/example-5.gjs
+++ b/tests/fixtures/my-app/input/app/components/example-5.gjs
@@ -1,0 +1,19 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class Example5Component extends Component {
+  @service('domain-1/business-logic') domain1BusinessLogic;
+  @service currentUser;
+  @service api;
+
+  @action async consent() {
+    const id = this.currentUser.user.id;
+
+    await this.api.post('consent', { id });
+  }
+
+  <template>
+    Template goes here
+  </template>
+}

--- a/tests/fixtures/my-app/input/tests/integration/components/example-1-test.gts
+++ b/tests/fixtures/my-app/input/tests/integration/components/example-1-test.gts
@@ -1,0 +1,31 @@
+import Service, {
+  inject as service,
+  type Registry as Services,
+} from '@ember/service';
+import { click, render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import Example1 from 'my-app/components/example-1';
+import { module, test } from 'qunit';
+
+module('Integration | Component | example-1', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function (assert) {
+    this.owner.register(
+      'service:domain-1/business-logic',
+      class Domain1BusinessLogicService extends Service {
+        @service private declare readonly intl: Services['intl'];
+
+        get message(): string {
+          return this.intl.t('hello.message', { name: 'Tomster' });
+        }
+      },
+    );
+  });
+
+  test('it renders', async function (assert) {
+    await render(<template><Example1 /></template>);
+
+    assert.ok(true);
+  });
+});

--- a/tests/fixtures/my-app/input/tests/integration/components/example-5-test.gjs
+++ b/tests/fixtures/my-app/input/tests/integration/components/example-5-test.gjs
@@ -1,0 +1,29 @@
+import Service, { inject } from '@ember/service';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import Example5 from 'my-app/components/example-5';
+import { module, test } from 'qunit';
+
+module('Integration | Component | example-5', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function (assert) {
+    this.owner.register(
+      'service:domain-1/business-logic',
+      class Domain1BusinessLogicService extends Service {
+        @inject intl;
+
+        get message() {
+          return this.intl.t('hello.message', { name: 'Tomster' });
+        }
+      },
+    );
+  });
+
+  test('it renders', async function (assert) {
+    await render(<template><Example5 /></template>);
+
+    assert.ok(true);
+  });
+});

--- a/tests/fixtures/my-app/input/tests/integration/components/example-6-test.gjs
+++ b/tests/fixtures/my-app/input/tests/integration/components/example-6-test.gjs
@@ -1,0 +1,29 @@
+import { computed } from '@ember/object';
+import Service, { inject as s } from '@ember/service';
+import { click, render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import Example6 from 'my-app/components/example-6';
+import { module, test } from 'qunit';
+
+module('Integration | Component | example-6', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function (assert) {
+    this.owner.register(
+      'service:domain-1/business-logic',
+      Service.extend({
+        intl: s('intl'),
+
+        message: computed(function () {
+          return this.intl.t('hello.message', { name: 'Tomster' });
+        }),
+      }),
+    );
+  });
+
+  test('it renders', async function (assert) {
+    await render(<template><Example6 /></template>);
+
+    assert.ok(true);
+  });
+});

--- a/tests/fixtures/my-app/output/app/components/example-1.gts
+++ b/tests/fixtures/my-app/output/app/components/example-1.gts
@@ -1,0 +1,27 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+
+import type ApiService from '../services/api';
+import type CurrentUserService from '../services/current-user';
+import type Domain1BusinessLogicService from '../services/domain-1/business-logic';
+
+export default class Example1Component extends Component {
+  @service('domain-1/business-logic')
+  declare domain1BusinessLogic: Domain1BusinessLogicService;
+
+  @service
+  declare currentUser: CurrentUserService;
+  @service
+  declare api: ApiService;
+
+  @action async consent(): Promise<void> {
+    const id = this.currentUser.user!.id;
+
+    await this.api.post('consent', { id });
+  }
+
+  <template>
+    Template goes here
+  </template>
+}

--- a/tests/fixtures/my-app/output/app/components/example-2.gts
+++ b/tests/fixtures/my-app/output/app/components/example-2.gts
@@ -1,0 +1,26 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+
+import type ApiService from '../services/api';
+import type CurrentUserService from '../services/current-user';
+import type Domain1BusinessLogicService from '../services/domain-1/business-logic';
+
+export default class Example2Component extends Component {
+  <template>
+    Template goes here
+  </template>
+
+  @service('domain-1/business-logic')
+  declare dbl: Domain1BusinessLogicService;
+  @service('current-user')
+  declare user: CurrentUserService;
+  @service('api')
+  declare xyz: ApiService;
+
+  @action async consent(): Promise<void> {
+    const id = this.user.user!.id;
+
+    await this.xyz.post('consent', { id });
+  }
+}

--- a/tests/fixtures/my-app/output/app/components/example-5.gjs
+++ b/tests/fixtures/my-app/output/app/components/example-5.gjs
@@ -1,0 +1,19 @@
+import { action } from '@ember/object';
+import { service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class Example5Component extends Component {
+  @service('domain-1/business-logic') domain1BusinessLogic;
+  @service currentUser;
+  @service api;
+
+  @action async consent() {
+    const id = this.currentUser.user.id;
+
+    await this.api.post('consent', { id });
+  }
+
+  <template>
+    Template goes here
+  </template>
+}

--- a/tests/fixtures/my-app/output/tests/integration/components/example-1-test.gts
+++ b/tests/fixtures/my-app/output/tests/integration/components/example-1-test.gts
@@ -1,0 +1,32 @@
+import Service, {
+  service,
+  type Registry as Services,
+} from '@ember/service';
+import { click, render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import Example1 from 'my-app/components/example-1';
+import { module, test } from 'qunit';
+
+module('Integration | Component | example-1', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function (assert) {
+    this.owner.register(
+      'service:domain-1/business-logic',
+      class Domain1BusinessLogicService extends Service {
+        @service
+        declare intl: Services['intl'];
+
+        get message(): string {
+          return this.intl.t('hello.message', { name: 'Tomster' });
+        }
+      },
+    );
+  });
+
+  test('it renders', async function (assert) {
+    await render(<template><Example1 /></template>);
+
+    assert.ok(true);
+  });
+});

--- a/tests/fixtures/my-app/output/tests/integration/components/example-5-test.gjs
+++ b/tests/fixtures/my-app/output/tests/integration/components/example-5-test.gjs
@@ -1,0 +1,29 @@
+import Service, { service } from '@ember/service';
+import { click, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { setupRenderingTest } from 'ember-qunit';
+import Example5 from 'my-app/components/example-5';
+import { module, test } from 'qunit';
+
+module('Integration | Component | example-5', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function (assert) {
+    this.owner.register(
+      'service:domain-1/business-logic',
+      class Domain1BusinessLogicService extends Service {
+        @service intl;
+
+        get message() {
+          return this.intl.t('hello.message', { name: 'Tomster' });
+        }
+      },
+    );
+  });
+
+  test('it renders', async function (assert) {
+    await render(<template><Example5 /></template>);
+
+    assert.ok(true);
+  });
+});

--- a/tests/fixtures/my-app/output/tests/integration/components/example-6-test.gjs
+++ b/tests/fixtures/my-app/output/tests/integration/components/example-6-test.gjs
@@ -1,0 +1,29 @@
+import { computed } from '@ember/object';
+import Service, { service } from '@ember/service';
+import { click, render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import Example6 from 'my-app/components/example-6';
+import { module, test } from 'qunit';
+
+module('Integration | Component | example-6', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function (assert) {
+    this.owner.register(
+      'service:domain-1/business-logic',
+      Service.extend({
+        intl: service('intl'),
+
+        message: computed(function () {
+          return this.intl.t('hello.message', { name: 'Tomster' });
+        }),
+      }),
+    );
+  });
+
+  test('it renders', async function (assert) {
+    await render(<template><Example6 /></template>);
+
+    assert.ok(true);
+  });
+});

--- a/tests/helpers/shared-test-setups/my-app.ts
+++ b/tests/helpers/shared-test-setups/my-app.ts
@@ -7,7 +7,7 @@ const codemodOptions: CodemodOptions = {
 
 const options: Options = {
   projectRoot: 'tmp/my-app',
-  src: ['app/**/*.{js,ts}', 'tests/**/*.{js,ts}'],
+  src: ['{app,tests}/**/*.{js,ts}'],
 };
 
 export { codemodOptions, options };

--- a/tests/helpers/shared-test-setups/my-app.ts
+++ b/tests/helpers/shared-test-setups/my-app.ts
@@ -7,7 +7,7 @@ const codemodOptions: CodemodOptions = {
 
 const options: Options = {
   projectRoot: 'tmp/my-app',
-  src: ['{app,tests}/**/*.{js,ts}'],
+  src: ['{app,tests}/**/*.{gjs,gts,js,ts}'],
 };
 
 export { codemodOptions, options };

--- a/tests/helpers/shared-test-setups/my-v1-addon.ts
+++ b/tests/helpers/shared-test-setups/my-v1-addon.ts
@@ -7,7 +7,7 @@ const codemodOptions: CodemodOptions = {
 
 const options: Options = {
   projectRoot: 'tmp/my-v1-addon',
-  src: ['addon/**/*.{js,ts}', 'tests/**/*.{js,ts}'],
+  src: ['{addon,tests}/**/*.{js,ts}'],
 };
 
 export { codemodOptions, options };

--- a/tests/helpers/shared-test-setups/my-v1-addon.ts
+++ b/tests/helpers/shared-test-setups/my-v1-addon.ts
@@ -7,7 +7,7 @@ const codemodOptions: CodemodOptions = {
 
 const options: Options = {
   projectRoot: 'tmp/my-v1-addon',
-  src: ['{addon,tests}/**/*.{js,ts}'],
+  src: ['{addon,tests}/**/*.{gjs,gts,js,ts}'],
 };
 
 export { codemodOptions, options };

--- a/tests/helpers/shared-test-setups/my-v2-addon.ts
+++ b/tests/helpers/shared-test-setups/my-v2-addon.ts
@@ -7,7 +7,7 @@ const codemodOptions: CodemodOptions = {
 
 const options: Options = {
   projectRoot: 'tmp/my-v2-addon',
-  src: ['src/**/*.{js,ts}'],
+  src: ['src/**/*.{gjs,gts,js,ts}'],
 };
 
 export { codemodOptions, options };


### PR DESCRIPTION
## Background

I created [`@codemod-utils/ast-template-tag`](https://github.com/ijlee2/codemod-utils/blob/3.4.0/packages/ast/template-tag/README.md) to help codemods support `*.{gjs,gts}` files (`<template>` tags). https://github.com/ijlee2/ember-codemod-remove-inject-as-service/commit/c5cfa2ef623ed2cc865424f2ff8b25194f4c490f illustrates how.
