### PR TITLE
Fixed lint errors

### DIFF
--- a/.changeset/bright-foxes-mix.md
+++ b/.changeset/bright-foxes-mix.md
@@ -1,0 +1,5 @@
+---
+"ember-codemod-remove-inject-as-service": minor
+---
+
+Fixed lint errors

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,12 +13,4 @@ export default [
     ],
   },
   ...baseConfiguration,
-  {
-    files: ['**/*.ts'],
-    rules: {
-      '@typescript-eslint/no-unsafe-argument': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
-    },
-  },
 ];

--- a/src/steps/update-project/update-class.ts
+++ b/src/steps/update-project/update-class.ts
@@ -1,5 +1,7 @@
 import { AST } from '@codemod-utils/ast-javascript';
 
+type Decorator = ReturnType<typeof AST.builders.decorator>;
+
 function isValueImport(
   importKind: 'type' | 'typeof' | 'value' | undefined,
 ): boolean {
@@ -36,7 +38,7 @@ function updateImportStatement(
       }
 
       path.node.specifiers = specifiers.map((specifier) => {
-        // @ts-expect-error: 'specifier.importKind' exists
+        // @ts-expect-error: Incorrect type
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         if (!isValueImport(specifier.importKind)) {
           return specifier;
@@ -78,16 +80,13 @@ function updateServiceDecorators(
   const traverse = AST.traverse(data.isTypeScript);
 
   const ast = traverse(file, {
-    visitCallExpression(node) {
-      this.traverse(node);
+    visitCallExpression(path) {
+      this.traverse(path);
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      switch (node.value.callee.type) {
+      switch (path.node.callee.type) {
         case 'Identifier': {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          if (node.value.callee.name === data.localName) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            node.value.callee.name = 'service';
+          if (path.node.callee.name === data.localName) {
+            path.node.callee.name = 'service';
           }
 
           break;
@@ -97,26 +96,23 @@ function updateServiceDecorators(
       return false;
     },
 
-    visitClassProperty(node) {
-      if (
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        !Array.isArray(node.value.decorators) ||
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        node.value.decorators.length !== 1
-      ) {
+    visitClassProperty(path) {
+      // @ts-expect-error: Incorrect type
+      const decorators = path.node.decorators as Decorator[];
+
+      if (!Array.isArray(decorators) || decorators.length !== 1) {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      const decorator = node.value.decorators[0];
+      const decorator = decorators[0]!;
       let isMatch = false;
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       switch (decorator.expression.type) {
         case 'CallExpression': {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          if (decorator.expression.callee.name === data.localName) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          if (
+            decorator.expression.callee.type === 'Identifier' &&
+            decorator.expression.callee.name === data.localName
+          ) {
             decorator.expression.callee.name = 'service';
             isMatch = true;
           }
@@ -125,9 +121,7 @@ function updateServiceDecorators(
         }
 
         case 'Identifier': {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           if (decorator.expression.name === data.localName) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             decorator.expression.name = 'service';
             isMatch = true;
           }
@@ -136,21 +130,21 @@ function updateServiceDecorators(
         }
       }
 
-      if (!isMatch || !data.isTypeScript) {
+      if (!isMatch) {
         return false;
       }
 
       // Stylistic choices
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (!decorator.trailingComments) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        node.value.accessibility = null;
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        node.value.declare = true;
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        node.value.definite = null;
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        node.value.readonly = null;
+      // @ts-expect-error: Incorrect type
+      if (data.isTypeScript && !decorator.trailingComments) {
+        // @ts-expect-error: Incorrect type
+        path.node.accessibility = null;
+        // @ts-expect-error: Incorrect type
+        path.node.declare = true;
+        // @ts-expect-error: Incorrect type
+        path.node.definite = null;
+        // @ts-expect-error: Incorrect type
+        path.node.readonly = null;
       }
 
       return false;

--- a/src/steps/update-project/update-class.ts
+++ b/src/steps/update-project/update-class.ts
@@ -37,6 +37,7 @@ function updateImportStatement(
 
       path.node.specifiers = specifiers.map((specifier) => {
         // @ts-expect-error: 'specifier.importKind' exists
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         if (!isValueImport(specifier.importKind)) {
           return specifier;
         }
@@ -80,9 +81,12 @@ function updateServiceDecorators(
     visitCallExpression(node) {
       this.traverse(node);
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       switch (node.value.callee.type) {
         case 'Identifier': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           if (node.value.callee.name === data.localName) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             node.value.callee.name = 'service';
           }
 
@@ -95,18 +99,24 @@ function updateServiceDecorators(
 
     visitClassProperty(node) {
       if (
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         !Array.isArray(node.value.decorators) ||
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         node.value.decorators.length !== 1
       ) {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const decorator = node.value.decorators[0];
       let isMatch = false;
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       switch (decorator.expression.type) {
         case 'CallExpression': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           if (decorator.expression.callee.name === data.localName) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             decorator.expression.callee.name = 'service';
             isMatch = true;
           }
@@ -115,7 +125,9 @@ function updateServiceDecorators(
         }
 
         case 'Identifier': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           if (decorator.expression.name === data.localName) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             decorator.expression.name = 'service';
             isMatch = true;
           }
@@ -129,10 +141,15 @@ function updateServiceDecorators(
       }
 
       // Stylistic choices
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (!decorator.trailingComments) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         node.value.accessibility = null;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         node.value.declare = true;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         node.value.definite = null;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         node.value.readonly = null;
       }
 


### PR DESCRIPTION
## Background

Incorrect use of `recast` had led to unnecessary type errors. In general, `node.value` should have read `path.node` instead.
